### PR TITLE
Fix startup of docker container

### DIFF
--- a/backend/src/mqttClient/mqttClient.ts
+++ b/backend/src/mqttClient/mqttClient.ts
@@ -23,7 +23,7 @@ import { Maybe } from './types';
 export let client: MqttClient;
 
 const mqttClient = () => {
-  client = client = connect('mqtts://localhost:8883', {rejectUnauthorized: false})
+  client = client = connect('mqtts://localhost:8883');
   console.info('starting Backend MQTT client');
   let vacuumMap: Maybe<VacuumMap> = null;
   let botInfo = new BotInfo();

--- a/backend/src/mqttClient/mqttClient.ts
+++ b/backend/src/mqttClient/mqttClient.ts
@@ -23,7 +23,7 @@ import { Maybe } from './types';
 export let client: MqttClient;
 
 const mqttClient = () => {
-  client = client = connect('mqtts://localhost:8883');
+  client = connect('mqtts://localhost:8883');
   console.info('starting Backend MQTT client');
   let vacuumMap: Maybe<VacuumMap> = null;
   let botInfo = new BotInfo();

--- a/backend/src/mqttClient/mqttClient.ts
+++ b/backend/src/mqttClient/mqttClient.ts
@@ -23,7 +23,7 @@ import { Maybe } from './types';
 export let client: MqttClient;
 
 const mqttClient = () => {
-  client = connect('mqtts://localhost:8883');
+  client = client = connect('mqtts://localhost:8883', {rejectUnauthorized: false})
   console.info('starting Backend MQTT client');
   let vacuumMap: Maybe<VacuumMap> = null;
   let botInfo = new BotInfo();

--- a/mysql/scripts/init.sql
+++ b/mysql/scripts/init.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS bot_events (
     id INT PRIMARY KEY AUTO_INCREMENT,
     evt_code INT NOT NULL,
     type  CHAR(5) NOT NULL,-- ERROR / EVENT
-    read TINYINT NOT NULL DEFAULT 0,
+    `read` TINYINT NOT NULL DEFAULT 0,
     timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS bot_reminders (
     id INT PRIMARY KEY AUTO_INCREMENT,
     name TINYTEXT NOT NULL,
     need_to_change TINYINT NOT NULL DEFAULT 0,
-    read TINYINT NOT NULL DEFAULT 1,
+    `read` TINYINT NOT NULL DEFAULT 1,
     timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -26,5 +26,5 @@ CREATE TABLE IF NOT EXISTS bot_saved_pattern (
 );
 
 
-INSERT INTO `bot_reminders` (`name`, `need_to_change`) VALUES ('dust_bag', '0', '1');
-INSERT INTO `bot_reminders` (`name`, `need_to_change`) VALUES ('mop', '0', '1');
+INSERT INTO `bot_reminders` (`name`, `need_to_change`, `read`) VALUES ('dust_bag', '0', '1');
+INSERT INTO `bot_reminders` (`name`, `need_to_change`,`read`) VALUES ('mop', '0', '1');


### PR DESCRIPTION
The latest changes have caused the docker container to not properly initialize due to two issues:

1. mqttClient did not accept the self signed certificate of the mqtt server instance
2. init.sql script was using a reserved keyword read which caused the creation of the database tables to fail