### PR TITLE
backend: MQTT: fix printing client errors messages

### DIFF
--- a/backend/src/mqttsServer.ts
+++ b/backend/src/mqttsServer.ts
@@ -1,4 +1,5 @@
 import Aedes from 'aedes';
+import { inspect } from 'node:util';
 import { Client } from 'aedes:client';
 import { Subscription } from 'aedes:packet';
 import { Socket } from 'socket.io';
@@ -15,9 +16,9 @@ const mqttsServer = (): Promise<Aedes> => {
 
     broker.on('clientError', (client: Client, error: Error) => {
       console.log(
-        `MQTT client \x1b[34m${client ? client.id : client}\x1b[0m  receive this error   \x1b[34m${JSON.stringify(
-          error,
-        )}\x1b[0m`,
+        `MQTT client \x1b[34m${client ? client.id : client}\x1b[0m  receive this error   \x1b[34m${
+          inspect(error, true, null, true)
+	}\x1b[0m`,
       ),
         reject();
     });


### PR DESCRIPTION
On client errors, up to now we could not know what the error message was because an empty object ('{}') was printed instead of the actual error message.

To fix it, print the message itself to the console.

As an example, it makes it possible to see the following client error in the logs when an MQTT bridge with notifications enabled is configured:
MQTT client cd52915a76b3.backend  receive this error   "$SYS/ topic is reserved"